### PR TITLE
Add coordinate features to PxlsBot

### DIFF
--- a/commands/coordinates.js
+++ b/commands/coordinates.js
@@ -1,0 +1,43 @@
+const { Command } = require('../command');
+
+const coordsRegex = /\(?([0-9]+)[., ]{1,2}([0-9]+)[., ]{0,2}([0-9]+)?x?\)?/i;
+
+async function execute (client, message) {
+  const args = message.content.split(' ').slice(1);
+  let url = false;
+
+  if (!isNaN(args[0]) && !isNaN(args[1])) { // !coords 30 30 28
+    url = `https://pxls.space/#x=${args[0]}&y=${args[1]}`;
+    if (!isNaN(args[2])) {
+      url += `&scale=${args[2]}`;
+    }
+  } else if (args[0].includes(',')) { // !coords (30, 30, 28)
+    let exec = coordsRegex.exec(args[0]);
+    if (exec && args[0].charAt(0) !== '(') { // abort if we have a paranthesis at pos 0 because the message-coordinate.js hook will handle it for us.
+      url = `https://pxls.space/#x=${exec[1]}&y=${exec[2]}`;
+      if (!isNaN(exec[3])) {
+        url += `&scale=${Math.max(0.5, parseFloat(exec[3]))}`;
+      }
+    }
+  }
+
+  if (url !== false) {
+    return message.channel.send(`<${url}>`);
+  } else {
+    return Promise.resolve();
+  }
+}
+
+const command = new Command(
+  'coordinates',
+  'Coordinates',
+  'Utility',
+  'Prints pxls coordinates',
+  'coordinates x y [zoom]',
+  [ 'coords' ],
+  false,
+  0
+);
+command.execute = execute;
+
+module.exports = { command };

--- a/events/message-coordinates.js
+++ b/events/message-coordinates.js
@@ -11,8 +11,9 @@ async function execute (message) {
   let exec = coordsRegex.exec(message.content);
   if (exec) {
     let url = `https://pxls.space/#x=${exec[1]}&y=${exec[2]}`;
-    if (!isNaN(exec[3]))
-      url += `&scale=${Math.max(0.5,  parseFloat(exec[3]))}`;
+    if (!isNaN(exec[3])) {
+      url += `&scale=${Math.max(0.5, parseFloat(exec[3]))}`;
+    }
     return message.channel.send(`<${url}>`);
   }
 }

--- a/events/message-coordinates.js
+++ b/events/message-coordinates.js
@@ -1,0 +1,20 @@
+const coordsRegex = /\(([0-9]+)[., ]{1,2}([0-9]+)[., ]{0,2}([0-9]+)?x?\)/i;
+
+/**
+ * Executed whenever a message is received over the WebSocket.
+ * @param {Discord.Message} message The message.
+ */
+async function execute (message) {
+  if (message.author.bot) {
+    return;
+  }
+  let exec = coordsRegex.exec(message.content);
+  if (exec) {
+    let url = `https://pxls.space/#x=${exec[1]}&y=${exec[2]}`;
+    if (!isNaN(exec[3]))
+      url += `&scale=${Math.max(0.5,  parseFloat(exec[3]))}`;
+    return message.channel.send(`<${url}>`);
+  }
+}
+
+module.exports = { name: 'message', execute };

--- a/index.js
+++ b/index.js
@@ -56,12 +56,12 @@ async function main () {
   }
   logger.info('Initializing events...');
   events = await getEvents(config.eventsPath);
-  events.forEach(async event => {
+  for (const event of events) {
     if (typeof event.init === 'function') {
       await event.init();
     }
     client.on(event.name, event.execute);
-  });
+  }
   logger.info('Logging in...');
   await login();
 }

--- a/utils.js
+++ b/utils.js
@@ -28,7 +28,7 @@ async function getEvents (eventsDirectory) {
       const required = require(pathToFile);
       if (typeof required.execute === 'function') {
         events.push({
-          name: file,
+          name: required.name || file,
           init: required.init,
           execute: required.execute
         });


### PR DESCRIPTION
This PR brings the following:
* Users can now link to coordinates in discord using the same format as in the main Pxls chat, e.g. `(XX, YY[, ZZ[x]])` / `(307, 290)`
* Users can now link to coordinates using a command, e.g. `!coordinates XX YY[ ZZ]` / `!coordinates 307 290`