### PR TITLE
Add infinity fix to coords module

### DIFF
--- a/commands/coordinates.js
+++ b/commands/coordinates.js
@@ -4,7 +4,7 @@ const coordsRegex = /\(?([0-9]+)[., ]{1,2}([0-9]+)[., ]{0,2}([0-9]+)?x?\)?/i;
 
 async function execute (client, message) {
   const args = message.content.split(' ').slice(1);
-  if (!args.length) return Promise.resolve();
+  if (!args.length) return;
 
   let coords = false;
   if (args.length > 1 && validateCoordinates(args[0], args[1], args[2])) {
@@ -24,7 +24,7 @@ async function execute (client, message) {
     }
   }
 
-  if (coords === false) return Promise.resolve();
+  if (coords === false) return;
   return message.channel.send(`<https://pxls.space/#x=${coords.x}&y=${coords.y}&scale=${coords.scale != null ? coords.scale : 20}>`);
 }
 

--- a/commands/coordinates.js
+++ b/commands/coordinates.js
@@ -4,22 +4,28 @@ const coordsRegex = /\(?([0-9]+)[., ]{1,2}([0-9]+)[., ]{0,2}([0-9]+)?x?\)?/i;
 
 async function execute (client, message) {
   const args = message.content.split(' ').slice(1);
-  let url = false;
+  if (!args.length) return Promise.resolve();
 
-  if (!isNaN(args[0]) && !isNaN(args[1])) { // !coords 30 30 28
-    url = `https://pxls.space/#x=${args[0]}&y=${args[1]}&scale=${isNaN(args[2]) ? '20' : args[2]}`;
-  } else if (args[0].includes(',')) { // !coords (30, 30, 28)
+  let coords = false;
+  if (args.length > 1 && validateCoordinates(args[0], args[1], args[2])) {
+    coords = {
+      x: args[0],
+      y: args[1],
+      scale: args[2]
+    };
+  } else if (args[0].includes(',') && args[0].charAt(0) !== '(') { // abort if we have a paranthesis at pos 0 because the message-coordinate.js hook will handle it for us.
     let exec = coordsRegex.exec(args[0]);
-    if (exec && args[0].charAt(0) !== '(') { // abort if we have a paranthesis at pos 0 because the message-coordinate.js hook will handle it for us.
-      url = `https://pxls.space/#x=${exec[1]}&y=${exec[2]}&scale=${isNaN(exec[3]) ? '20' : exec[3]}`;
+    if (validateCoordinates(exec[1], exec[2], exec[3])) {
+      coords = {
+        x: exec[1],
+        y: exec[2],
+        scale: exec[3]
+      };
     }
   }
 
-  if (url !== false) {
-    return message.channel.send(`<${url}>`);
-  } else {
-    return Promise.resolve();
-  }
+  if (coords === false) return Promise.resolve();
+  return message.channel.send(`<https://pxls.space/#x=${coords.x}&y=${coords.y}&scale=${coords.scale != null ? coords.scale : 20}>`);
 }
 
 const command = new Command(
@@ -34,4 +40,16 @@ const command = new Command(
 );
 command.execute = execute;
 
-module.exports = { command };
+/**
+ * Verifies that the given x/y/scale are finite and <= $maximum
+ * @param {string|number} x The x component
+ * @param {string|number} y The y component
+ * @param {string|number} [scale=20] The scale component
+ * @param {number} [maximum=1000000] The maximum intval that x/y/scale can be
+ * @returns {boolean} Whether or not the arguments are valid
+ */
+function validateCoordinates (x, y, scale = 20, maximum = 1000000) {
+  return ((isFinite(x) && isFinite(y) && isFinite(scale)) && parseFloat(x) <= maximum && parseFloat(y) <= maximum && parseFloat(scale) <= maximum);
+}
+
+module.exports = { command, validateCoordinates };

--- a/events/message-coordinates.js
+++ b/events/message-coordinates.js
@@ -1,3 +1,4 @@
+const { validateCoordinates } = require('../commands/coordinates');
 const coordsRegex = /\(([0-9]+)[., ]{1,2}([0-9]+)[., ]{0,2}([0-9]+)?x?\)/i;
 
 /**
@@ -9,7 +10,7 @@ async function execute (message) {
     return;
   }
   let exec = coordsRegex.exec(message.content);
-  if (exec) {
+  if (exec && validateCoordinates(exec[1], exec[2], exec[3])) {
     return message.channel.send(`<https://pxls.space/#x=${exec[1]}&y=${exec[2]}&scale=${isNaN(exec[3]) ? '20' : exec[3]}>`);
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node .",
-    "test": "./node_modules/semistandard/bin/cmd.js"
+    "test": "node ./node_modules/semistandard/bin/cmd.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR brings the following:
- Fixes a bug relating to the coordinates module that allows long integers to be parsed into the URL
- Fixes a (potential) typo in `package.json` which doesn't run the `test` script properly on Windows machines