### PR TITLE
Use linting rules that require type checking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,15 +4,20 @@
   "plugins": [
     "@typescript-eslint"
   ],
+  "parserOptions": {
+    "project": [ "tsconfig.json" ]
+  },
   "extends": [
     "semistandard",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
   ],
   "env": {
     "node": true
   },
   "rules": {
     "no-console": ["error", {"allow": ["info", "warn", "error", "debug", "trace"]}],
-    "space-before-function-paren": "off"
+    "space-before-function-paren": "off",
+    "no-void": ["error", {"allowAsStatement": true}]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "ts-node src/index.ts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "verify-ts": "tsc --noEmit",
+    "check": "npm run lint || npm run verify-ts"
   },
   "repository": {
     "type": "git",

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,4 @@
 import * as Discord from 'discord.js';
-import { Message } from 'discord.js';
 
 interface CommandData {
   id: string;
@@ -23,7 +22,7 @@ export class Command implements CommandData {
   public permissions = 0;
 
   init: () => Promise<void>;
-  execute: (client: Discord.Client, message: Discord.Message) => Promise<Message | void>;
+  execute: (client: Discord.Client, message: Discord.Message) => void | Promise<void>;
 
   constructor(data: CommandData) {
     this.id = data.id;

--- a/src/commands/board.ts
+++ b/src/commands/board.ts
@@ -75,7 +75,7 @@ const heatmapColor = new Color(205, 92, 92);
 const virginmapColor = new Color(0, 255, 0);
 const placemapColor = Color.rainbow.white;
 
-async function execute(client: Discord.Client, message: Discord.Message) {
+async function execute(client: Discord.Client, message: Discord.Message): Promise<void> {
   const args = message.content.split(' ');
   const embed = new Discord.MessageEmbed();
   embed.setTimestamp();
@@ -100,12 +100,14 @@ async function execute(client: Discord.Client, message: Discord.Message) {
   const info = await getInfo();
   if (info == null) {
     embed.setDescription('Could not get Pxls information.');
-    return message.channel.send(embed);
+    await message.channel.send(embed);
+    return;
   }
   const boardData = await getBoard(type);
   if (boardData == null) {
     embed.setDescription('Could not get the board data.');
-    return message.channel.send(embed);
+    await message.channel.send(embed);
+    return;
   }
   const colorPalette = info.palette.map(hex => Color.fromHex(hex));
   const png = new PNG({
@@ -162,7 +164,7 @@ async function execute(client: Discord.Client, message: Discord.Message) {
   const attachment = new Discord.MessageAttachment(PNG.sync.write(png.pack()), 'boarddata.png');
   embed.attachFiles([attachment]);
   embed.setImage('attachment://boarddata.png');
-  return message.channel.send(embed);
+  await message.channel.send(embed);
 }
 
 export const command = new Command({

--- a/src/commands/coordinates.ts
+++ b/src/commands/coordinates.ts
@@ -32,7 +32,7 @@ async function execute(client: Discord.Client, message: Discord.Message) {
   }
 
   if (typeof coords !== 'undefined') {
-    message.channel.send(`<https://pxls.space/#x=${coords.x}&y=${coords.y}&scale=${coords.scale ?? 20}>`);
+    await message.channel.send(`<https://pxls.space/#x=${coords.x}&y=${coords.y}&scale=${coords.scale ?? 20}>`);
   }
 }
 

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -2,18 +2,19 @@ import * as Discord from 'discord.js';
 import { Command } from '../command';
 import { Color } from '../utils';
 
-async function execute(client, message) {
+async function execute(client: Discord.Client, message: Discord.Message) {
   const goodPingColor = new Color(0, 255, 0);
   const badPingColor = new Color(255, 0, 0);
   const embed = new Discord.MessageEmbed();
   embed.setDescription(`
-    **Average Ping:** ${Math.floor(client.ping)}ms
+    **Average Ping:** ${Math.floor(client.ws.ping)}ms
 
-    **Pings (most recent first):** ${client.pings.map(ping => Math.floor(ping) + 'ms').join(', ')}
+    **Per Shard:**
+    ${client.ws.shards.map(shard => `${shard.id}: ${Math.floor(shard.ping)}ms`).join('\n')}
   `);
-  const color = Color.lerp(client.ping / 1000, goodPingColor, badPingColor);
+  const color = Color.lerp(client.ws.ping / 1000, goodPingColor, badPingColor);
   embed.setColor(color.toColorResolvable());
-  return message.channel.send(embed);
+  await message.channel.send(embed);
 }
 
 export const command = new Command({

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,7 @@ type Config = {
 let conf: Config;
 try {
   const confJSON = fs.readFileSync(joinPath(__dirname, '../config.json'), 'utf-8');
-  conf = JSON.parse(confJSON);
+  conf = JSON.parse(confJSON) as Config;
 } catch (err) {
   console.error('Cannot read configuration file', err);
   process.exit(1);

--- a/src/events/error.ts
+++ b/src/events/error.ts
@@ -8,11 +8,11 @@ export const name = 'error';
  * Executed whenever a discord.js WebSocket error occurs.
  * @param {error} err The error.
  */
-export async function execute(err: Error): Promise<void> {
+export function execute(err: Error): void {
   if (err.name === 'ENOTFOUND') {
     logger.error('Lost connection to Discord, will attempt reconnect in 30 seconds...');
-    setTimeout(async () => {
-      await login();
+    setTimeout(() => {
+      void login();
     }, config.get('reconnectTimeout'));
     return;
   }

--- a/src/events/message-coordinates.ts
+++ b/src/events/message-coordinates.ts
@@ -15,6 +15,6 @@ export async function execute(message: Discord.Message): Promise<void> {
   }
   const exec = coordsRegex.exec(message.content);
   if (exec && validateCoordinates(exec[1], exec[2], exec[3])) {
-    message.channel.send(`<https://pxls.space/#x=${exec[1]}&y=${exec[2]}&scale=${exec[3] ?? '20'}>`);
+    await message.channel.send(`<https://pxls.space/#x=${exec[1]}&y=${exec[2]}&scale=${exec[3] ?? '20'}>`);
   }
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -7,6 +7,9 @@ export const name = 'ready';
 /** Executed when the client successfully logs in. */
 export async function execute(): Promise<void> {
   logger.info('Logged in as ' + client.user.tag + '.');
-  client.user.setPresence(config.get('presence'));
-  logger.debug('Presence set to:', config.get('presence'));
+  const presence = config.get('presence');
+  if (presence != null) {
+    await client.user.setPresence(config.get('presence'));
+    logger.debug('Presence set to:', config.get('presence'));
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export let events: EventObject[];
 export async function login(): Promise<void> {
   await client.login(config.get('token')).catch(err => {
     logger.error(err);
-    exit(1);
+    return exit(1);
   });
 }
 
@@ -46,7 +46,7 @@ async function main() {
   logger.debug('Testing database configuration...');
   try {
     const connection = await database.connect();
-    await connection.release();
+    connection.release();
     logger.debug('Database successfully pinged.');
   } catch (err) {
     logger.error(err);
@@ -77,6 +77,8 @@ export async function exit(code = 0): Promise<void> {
 }
 
 // Handles CTRL-C
-process.on('SIGINT', () => exit());
+process.on('SIGINT', () => {
+  void exit();
+});
 
-main();
+void main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"include": ["src/**/*"],
+	"exclude": ["node_modules/**/*"]
+}


### PR DESCRIPTION
This is a continuation of the addition of eslint to lint Typescript files.

The default `@typescript-eslint/recommended` doesn't include rules that require type checking, so this PR includes `@typescript-eslint/recommended-requiring-type-checking` rules to check for those too.

Due to the new rules being enforced, some miscellaneous changes were done:
- Modified no-void rule on eslint to allow for "void" at the beginning of statements. This is useful for calling promises that we don't care about the result of.
- Remove pad function from util. Functions that used it now use String.padStart() or String.padEnd().
- Use fs/promise instead of fs wherever possible to avoid blocking operations.
- Make util.find resolve to false when no valid type is given.
- Move util.getPrefix to the config command file..
- `await` or `void` all promises.
- Make Command.execute return Promise<void> | void.
- Allow presence to be unset/null in config.

This PR also:
- Adds a tsconfig.json file.
- Adds scripts for verifying that Typescript files don't have errors.
- Makes `!ping` return per shard ping instead of the last pings. This is because Discord.js v12 stopped providing this information to us.
- Fixes `!config create` not checking database errors correctly.
