### PR TITLE
Pass config presence to client constructor instead of setting it on ready.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -14,7 +14,7 @@
 	},
 	"presence": {
 		"status": "online",
-		"game": {
+		"activity": {
 			"name": "pxls.space",
 			"type": "PLAYING",
 			"url": "https://pxls.space/"

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,15 +1,9 @@
 import { client } from '../index';
 import * as logger from '../logger';
-import * as config from '../config';
 
 export const name = 'ready';
 
 /** Executed when the client successfully logs in. */
-export async function execute(): Promise<void> {
+export function execute(): void {
   logger.info('Logged in as ' + client.user.tag + '.');
-  const presence = config.get('presence');
-  if (presence != null) {
-    await client.user.setPresence(config.get('presence'));
-    logger.debug('Presence set to:', config.get('presence'));
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import * as logger from './logger';
 import { EventObject, getEvents } from './utils';
 import * as config from './config';
 
-export const client = new Discord.Client();
+export const client = new Discord.Client({
+  presence: config.get('presence')
+});
 
 /**
  * A database connection pool, set during initialization.


### PR DESCRIPTION
Small optimization which sets the presence on login as opposed to on ready (which would about the second or so in which the bot is online but without the custom presence on boot).

This also fixes the example config using "game" instead of "activity" for presence, [which was changed on Discord.js v12](https://discordjs.guide/additional-info/changes-in-v12.html#presence)