### PR TITLE
Allow for receiving events of objects not in the cache.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -49,6 +49,9 @@ export class Client extends Discord.Client {
   }
 
   private async handleMessageCommand(message: Discord.Message) {
+    if (message.partial) {
+      return;
+    }
     if (message.author.bot) {
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import * as config from './config';
 const EXTENSION_BASE_PATH = path.resolve(__dirname, './extensions');
 
 export const client = new Client({
-  presence: config.get('presence')
+  presence: config.get('presence'),
+  partials: ['USER', 'CHANNEL', 'GUILD_MEMBER', 'MESSAGE', 'REACTION']
 });
 
 /** Attempts to log into Discord. */


### PR DESCRIPTION
Enables events to be triggered for partial objects. This is helpful, e.g., for receiving reaction events for messages no in the cache.

More on partials: https://discord.js.org/#/docs/main/stable/topics/partials