### PR TITLE
Fix theoretical max size of a Discord Snowflake

### DIFF
--- a/src/extensions/auditlog.ts
+++ b/src/extensions/auditlog.ts
@@ -158,8 +158,8 @@ export async function setup(client: Client): Promise<void> {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS auditlog (
         id SERIAL NOT NULL PRIMARY KEY,
-        guild_id VARCHAR(18) NOT NULL,
-        user_id VARCHAR(18) NOT NULL,
+        guild_id VARCHAR(20) NOT NULL,
+        user_id VARCHAR(20) NOT NULL,
         command_id TEXT,
         message TEXT,
         timestamp TIMESTAMP NOT NULL DEFAULT NOW()

--- a/src/extensions/config.ts
+++ b/src/extensions/config.ts
@@ -29,7 +29,7 @@ const columns = {
     databaseToObject: (_client, value) => value
   } as ConfigValueDefinition<string, string>,
   'starboard_channel': {
-    dbType: 'VARCHAR(18)',
+    dbType: 'VARCHAR(20)',
     stringToDatabase: async (client, value) => {
       if (value.toLowerCase() === 'none') {
         return null;
@@ -316,7 +316,7 @@ export async function setup(client: Client): Promise<void> {
   try {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS config (
-        guild_id VARCHAR(18) NOT NULL PRIMARY KEY,
+        guild_id VARCHAR(20) NOT NULL PRIMARY KEY,
         ${Object.entries(columns).map(([name, { dbType }]) => `${name} ${dbType}`).join(',')}
       )
     `));

--- a/src/extensions/starboard.ts
+++ b/src/extensions/starboard.ts
@@ -159,9 +159,9 @@ export async function setup(client: Client): Promise<void> {
   try {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS starboard_messages (
-        guild_id VARCHAR(18) NOT NULL,
-        source_message_id VARCHAR(18) NOT NULL,
-        board_message_id VARCHAR(18) NOT NULL
+        guild_id VARCHAR(20) NOT NULL,
+        source_message_id VARCHAR(20) NOT NULL,
+        board_message_id VARCHAR(20) NOT NULL
       );
       CREATE UNIQUE INDEX IF NOT EXISTS starboard_guild_source_pair
       ON starboard_messages(guild_id, source_message_id);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,7 +176,7 @@ export class Color {
  * @returns {boolean} Whether the input snowflake is valid or not.
  */
 export function isSnowflake(input: string): boolean {
-  return !isNaN(Number(input)) && input.length === 18;
+  return !isNaN(Number(input)) && input.length > 0 && input.length <= 20;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,6 @@
 import * as Discord from 'discord.js';
 
 /**
- * Multiplies the specified numbers.
- * @param {number} x The number to multiply by.
- * @param  {...number} values The numbers to multiply.
- * @return {number[]} The multiplied numbers.
- */
-export function multiplyBy(x: number, ...values: number[]): number[] {
-  const multiplied: number[] = [];
-  values.forEach(value => multiplied.push(value * x));
-  return multiplied;
-}
-
-/**
  * Clamps the specified number between min and max.
  * @param {number} x The number to clamp.
  * @param {number} min The minimum value.
@@ -254,8 +242,14 @@ export const findChannel = (message: Discord.Message, input: string): Discord.Gu
     // Attempt to get the channel by the ID
     return message.guild.channels.cache.get(input) ?? false;
   } else {
-    // Attempt to get the channel by the name
-    return message.guild.channels.cache.find(v => v.name.toLowerCase() === input.toLowerCase()) ?? false;
+    const match = /^(?:<#)?(?<id>\d+)>?$/.exec(input);
+    if (match != null) {
+      // Attempt to get channel by mention
+      return message.guild.channels.cache.get(match.groups.id) ?? false;
+    } else {
+      // Attempt to get the channel by the name
+      return message.guild.channels.cache.find(v => v.name.toLowerCase() === input.toLowerCase()) ?? false;
+    }
   }
 };
 


### PR DESCRIPTION
Snowflakes in Discord represent 64 bit numbers. The maximum unsigned 64 bit integer is 18446744073709552000, which as text contains 20 characters, more than 18.

This fixes the check in `util.isSnowflake()` and changes the types of database columns that previously assumed Discord IDs were at most 18 characters long.

### Database changes
````sql
ALTER TABLE auditlog ALTER COLUMN guild_id TYPE VARCHAR(20);
ALTER TABLE auditlog ALTER COLUMN user_id TYPE VARCHAR(20);

ALTER TABLE config ALTER COLUMN guild_id TYPE VARCHAR(20);
ALTER TABLE config ALTER COLUMN starboard_channel TYPE VARCHAR(20);

ALTER TABLE starboard_messages ALTER COLUMN guild_id TYPE VARCHAR(20);
ALTER TABLE starboard_messages ALTER COLUMN source_message_id TYPE VARCHAR(20);
ALTER TABLE starboard_messages ALTER COLUMN board_message_id TYPE VARCHAR(20);
````