### PR TITLE
Housekeeping of utils and JSDocs

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -38,8 +38,8 @@ export class Command implements CommandData {
   }
 
   /**
-   * @param {Discord.GuildMember} member - The guild member.
-   * @returns {boolean} Whether or not the specified member has permission to run this command.
+   * @param member - The guild member.
+   * @returns Whether or not the specified member has permission to run this command.
    */
   hasPermission(member: Discord.GuildMember): boolean {
     return member.hasPermission(this.permissions);

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,22 +1,15 @@
 import * as pg from 'pg';
 
-/**
- * A database connection pool, set during initialization.
- * @property {pg.Pool}
- */
+/** A database connection pool, set during initialization. */
 export let database: pg.Pool;
 
-/**
- * Gets the database pool.
- * @returns {pg.Pool}
- */
+/** Gets the database pool. */
 export function getPool(): pg.Pool {
   return database;
 }
 
 /**
  * Gets a database pool connection.
- * @returns {pg.PoolClient}
  */
 export function getConnection(): Promise<pg.PoolClient> {
   return database.connect();
@@ -43,10 +36,7 @@ export async function withConnection<A extends unknown[], T = unknown>(
   }
 }
 
-/**
- * Initializes the database pool.
- * @param config {pg.PoolConfig}
- */
+/** Initializes the database pool. */
 export function init(config: pg.PoolConfig): void {
   database = new pg.Pool(config);
 }

--- a/src/extensions/auditlog.ts
+++ b/src/extensions/auditlog.ts
@@ -20,9 +20,9 @@ type DatabaseAuditLog = {
 
 /**
  * Inserts an audit log entry.
- * @param {pg.PoolClient} connection The database connection.
- * @param {Discord.Message} message The message.
- * @param {string} commandID The command ID.
+ * @param connection The database connection.
+ * @param message The message.
+ * @param commandID The command ID.
  */
 export async function insertAuditLog(connection: pg.PoolClient, message: Discord.Message, commandID: string): Promise<void> {
   try {

--- a/src/extensions/auditlog.ts
+++ b/src/extensions/auditlog.ts
@@ -158,8 +158,8 @@ export async function setup(client: Client): Promise<void> {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS auditlog (
         id SERIAL NOT NULL PRIMARY KEY,
-        guild_id VARCHAR(18) NOT NULL,
-        user_id VARCHAR(18) NOT NULL,
+        guild_id VARCHAR(20) NOT NULL,
+        user_id VARCHAR(20) NOT NULL,
         command_id TEXT,
         message TEXT,
         timestamp TIMESTAMP NOT NULL DEFAULT NOW()

--- a/src/extensions/board.ts
+++ b/src/extensions/board.ts
@@ -18,7 +18,7 @@ interface PxlsInfo {
 
 /**
  * Gets Pxls information.
- * @returns {Promise<PxlsInfo>} The info.
+ * @returns The info.
  */
 async function getInfo(): Promise<PxlsInfo> {
   const reqURL = `${config.getGameURL()}/info`;
@@ -40,7 +40,7 @@ enum BoardType {
 /**
  * Gets the board by type.
  * @param type The board type.
- * @returns {Promise<Buffer | null>} The board data.
+ * @returns The board data.
  */
 async function getBoard(type: BoardType): Promise<Buffer | null> {
   // TODO: Configurable board source

--- a/src/extensions/config.ts
+++ b/src/extensions/config.ts
@@ -29,7 +29,7 @@ const columns = {
     databaseToObject: (_client, value) => value
   } as ConfigValueDefinition<string, string>,
   'starboard_channel': {
-    dbType: 'VARCHAR(18)',
+    dbType: 'VARCHAR(20)',
     stringToDatabase: async (client, value) => {
       if (value.toLowerCase() === 'none') {
         return null;
@@ -316,7 +316,7 @@ export async function setup(client: Client): Promise<void> {
   try {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS config (
-        guild_id VARCHAR(18) NOT NULL PRIMARY KEY,
+        guild_id VARCHAR(20) NOT NULL PRIMARY KEY,
         ${Object.entries(columns).map(([name, { dbType }]) => `${name} ${dbType}`).join(',')}
       )
     `));

--- a/src/extensions/config.ts
+++ b/src/extensions/config.ts
@@ -84,9 +84,9 @@ export type DatabaseGuildConfig = {
 
 /**
  * Returns the value of a config column for the guild.
- * @param {pg.PoolClient} connection The connection.
- * @param {Client} client The Discord Client.
- * @param {string} guildID The guild ID.
+ * @param connection The connection.
+ * @param client The Discord Client.
+ * @param guildID The guild ID.
  * @returns The config value, or undefined if the guild has not setup config and no default is set.
  */
 export async function get<CN extends keyof typeof columns>(
@@ -124,10 +124,10 @@ export async function get<CN extends keyof typeof columns>(
 
 /**
  * Returns the configured prefix for the guild, or the default one if none.
- * @param {pg.PoolClient} connection The connection.
- * @param {Client} client The Discord Client.
- * @param {string} guildID The guild ID.
- * @returns {Promise<string>} The prefix.
+ * @param connection The connection.
+ * @param client The Discord Client.
+ * @param guildID The guild ID.
+ * @returns The prefix.
  */
 export const getPrefix = (
   connection: pg.PoolClient,

--- a/src/extensions/starboard.ts
+++ b/src/extensions/starboard.ts
@@ -159,9 +159,9 @@ export async function setup(client: Client): Promise<void> {
   try {
     await database.withConnection((connection) => connection.query(`
       CREATE TABLE IF NOT EXISTS starboard_messages (
-        guild_id VARCHAR(18) NOT NULL,
-        source_message_id VARCHAR(18) NOT NULL,
-        board_message_id VARCHAR(18) NOT NULL
+        guild_id VARCHAR(20) NOT NULL,
+        source_message_id VARCHAR(20) NOT NULL,
+        board_message_id VARCHAR(20) NOT NULL
       );
       CREATE UNIQUE INDEX IF NOT EXISTS starboard_guild_source_pair
       ON starboard_messages(guild_id, source_message_id);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -82,8 +82,8 @@ const LevelToPrintFn: { [level in LogLevel[number]]: (...args: unknown[]) => voi
 
 /**
  * Logs to the console, and if configured, a log file.
- * @param {string} level The logging level.
- * @param {...any} x The content to log.
+ * @param level The logging level.
+ * @param x The content to log.
  */
 export function log(level?: LogLevel[number], ...x: unknown[]): void {
   // If log is called without the level, move the thing being logged over to x

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,7 +176,7 @@ export class Color {
  * @returns {boolean} Whether the input snowflake is valid or not.
  */
 export function isSnowflake(input: string): boolean {
-  return !isNaN(Number(input)) && input.length === 18;
+  return !isNaN(Number(input)) && input.length > 0 && input.length <= 20;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,6 @@
 import * as Discord from 'discord.js';
 
 /**
- * Multiplies the specified numbers.
- * @param {number} x The number to multiply by.
- * @param  {...number} values The numbers to multiply.
- * @return {number[]} The multiplied numbers.
- */
-export function multiplyBy(x: number, ...values: number[]): number[] {
-  const multiplied: number[] = [];
-  values.forEach(value => multiplied.push(value * x));
-  return multiplied;
-}
-
-/**
  * Clamps the specified number between min and max.
  * @param {number} x The number to clamp.
  * @param {number} min The minimum value.
@@ -254,8 +242,14 @@ export const findChannel = (message: Discord.Message, input: string): Discord.Gu
     // Attempt to get the channel by the ID
     return message.guild.channels.cache.get(input) ?? false;
   } else {
-    // Attempt to get the channel by the name
-    return message.guild.channels.cache.find(v => v.name.toLowerCase() === input.toLowerCase()) ?? false;
+    const match = /^(?:<#)?(?<id>\d+)>?$/.exec(input);
+    if (match != null) {
+      // Attempt to get channel by mention
+      return message.guild.channels.cache.get(match.groups.id) ?? false;
+    } else {
+      // Attempt to get the channel by the name
+      return message.guild.channels.cache.find(v => v.name.toLowerCase() === input.toLowerCase()) ?? false;
+    }
   }
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,10 @@ import * as Discord from 'discord.js';
 
 /**
  * Clamps the specified number between min and max.
- * @param {number} x The number to clamp.
- * @param {number} min The minimum value.
- * @param {number} max The maximum value.
- * @returns {number} The clamped number.
+ * @param x The number to clamp.
+ * @param min The minimum value.
+ * @param max The maximum value.
+ * @returns The clamped number.
  */
 export function clamp(x: number, min: number, max: number): number {
   return x < min ? min : x > max ? max : x;
@@ -14,10 +14,10 @@ export function clamp(x: number, min: number, max: number): number {
 /**
  * Shortens a string up to the specified max length, with a string appended at the end.
  * e.g.: ellipsis('abcdefg', 4) => 'abc…'
- * @param {string} str The string to shorten.
- * @param {number} maxLength The maximum length for the shortened string.
- * @param {string} [suffix=…] The string to append at the end in case the input exceeds maxLength.
- * @returns {string} The shortened string.
+ * @param str The string to shorten.
+ * @param maxLength The maximum length for the shortened string.
+ * @param [suffix=…] The string to append at the end in case the input exceeds maxLength.
+ * @returns The shortened string.
  */
 export function ellipsis(str: string, maxLength: number, suffix = '…'): string {
   return str.length > maxLength ? str.substring(0, maxLength - suffix.length) + suffix : str;
@@ -51,10 +51,10 @@ export class Color {
    * Create a new Color.
    * Color values must be from 0 to 255.
    * @class
-   * @param {number} red The red color value.
-   * @param {number} green The green color value.
-   * @param {number} blue The blue color value.
-   * @param {number} alpha The alpha color value.
+   * @param red The red color value.
+   * @param green The green color value.
+   * @param blue The blue color value.
+   * @param alpha The alpha color value.
    * Defaults to 255 if unspecified.
    */
   constructor(red: number, green: number, blue: number, alpha = 255) {
@@ -67,7 +67,7 @@ export class Color {
   /**
    * Parses the input hex color to a Color.
    * @param hex The hex color.
-   * @returns {Color} The parsed color.
+   * @returns The parsed color.
    */
   static fromHex(hex: string): Color {
     hex = hex.replace('#', '');
@@ -80,10 +80,10 @@ export class Color {
 
   /**
    * Calculates the color value of x between from and to.
-   * @param {number} x The current value, between 0 and 1.
-   * @param {Color} min The minimum color.
-   * @param {Color} max The maximum color.
-   * @returns {Color} The color value.
+   * @param x The current value, between 0 and 1.
+   * @param min The minimum color.
+   * @param max The maximum color.
+   * @returns The color value.
    */
   static lerp(x: number, min: Color, max: Color): Color {
     const rangeR = clamp(min.red + ((max.red - min.red) * x), 0, 255);
@@ -95,9 +95,9 @@ export class Color {
 
   /**
    * Calculates the sum of this color and the other color.
-   * @param {Color} other The other color.
-   * @param {number?} withAlpha The output alpha.
-   * @returns {Color} The summed color.
+   * @param other The other color.
+   * @param withAlpha The output alpha.
+   * @returns The summed color.
    * @see {@link add}
    */
   add(other: Color, withAlpha?: number): Color {
@@ -106,11 +106,11 @@ export class Color {
 
   /**
    * Calculates the sum of the first and second color.
-   * @param {Color} first The first color.
-   * @param {Color} second The second color.
-   * @param {number?} withAlpha The output alpha.
+   * @param first The first color.
+   * @param second The second color.
+   * @param withAlpha The output alpha.
    * Set this param if summing alpha values is undesired.
-   * @returns {Color} The summed color.
+   * @returns The summed color.
    */
   static add(first: Color, second: Color, withAlpha?: number): Color {
     const red = clamp(first.red + second.red, 0, 255);
@@ -125,9 +125,9 @@ export class Color {
 
   /**
    * Calculates the difference of this color and the other color.
-   * @param {Color} other The other color.
-   * @param {number?} withAlpha The output alpha.
-   * @returns {Color} The differed color.
+   * @param other The other color.
+   * @param withAlpha The output alpha.
+   * @returns The differed color.
    * @see {@link subtract}
    */
   subtract(other: Color, withAlpha?: number): Color {
@@ -136,11 +136,11 @@ export class Color {
 
   /**
   * Calculates the difference of the first and second color.
-  * @param {Color} first The first color.
-  * @param {Color} second The second color.
-  * @param {number?} withAlpha The output alpha.
+  * @param first The first color.
+  * @param second The second color.
+  * @param withAlpha The output alpha.
   * Set this param if summing alpha values is undesired.
-  * @returns {Color} The differed color.
+  * @returns The differed color.
   */
   static subtract(first: Color, second: Color, withAlpha?: number): Color {
     const red = clamp(first.red - second.red, 0, 255);
@@ -155,8 +155,8 @@ export class Color {
 
   /**
    * Returns the color values in an array.
-   * @param {boolean} withAlpha Whether to return with the alpha or not.
-   * @returns {number[]} The color values.
+   * @param withAlpha Whether to return with the alpha or not.
+   * @returns The color values.
    */
   toArray(): [ number, number, number, number ] {
     return [this.red, this.green, this.blue, this.alpha];
@@ -164,7 +164,7 @@ export class Color {
 
   /**
    * Returns the color values in a Discord.ColorResolvable array.
-   * @returns {number[]} The color values.
+   * @returns The color values.
    */
   toColorResolvable(): [ number, number, number ] {
     return [this.red, this.green, this.blue];
@@ -298,11 +298,11 @@ export function findGuildChannel(manager: Discord.Guild | Discord.GuildChannelMa
 
 /**
  * Truncates the specified text and appends chars to the end, if specified.
- * @param {string} x The text to truncate.
- * @param {number} max The max length of the text.
- * @param {string} chars The characters to append if the length of the text exceeds max.
- * @param {boolean} inward Whether chars should be appended inwards or outwards.
- * @return {string} The truncated text.
+ * @param x The text to truncate.
+ * @param max The max length of the text.
+ * @param chars The characters to append if the length of the text exceeds max.
+ * @param inward Whether chars should be appended inwards or outwards.
+ * @return The truncated text.
  */
 export function truncate(x: string, max: number, chars: string, inward: boolean): string {
   let retVal = x;
@@ -321,10 +321,10 @@ export function truncate(x: string, max: number, chars: string, inward: boolean)
  * This is similar to s.split(sep, n), but if the text doesn't contain
  * enough of the separator the rest of the string will be the last element
  * of the result.
- * @param {string} s The text to split.
- * @param {number} sep The separator.
- * @param {string} n The amount of times to split.
- * @return {string[]} An array of 1 to n chunks from the original text.
+ * @param s The text to split.
+ * @param sep The separator.
+ * @param n The amount of times to split.
+ * @return An array of 1 to n chunks from the original text.
  */
 export function splitN(s: string, sep: string, n: number): string[] {
   const acc: string[] = [];


### PR DESCRIPTION
- Rework `utils.findX()` functions so that they are easier to use.
  - Make config extension use `utils.findGuildChannel()`
- Remove type information from JSDocs
- Fix config's `objectToString()` taking in the database value instead of the JS Object when executed through !config
  - Fixes starboard_channel appearing as "#undefined" when checked through !config