### PR TITLE
Fix logger month being off by one

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@ import * as config from './config';
 
 /** Returns the date in YYYY-MM-DD format. */
 export function getDate(date: Date = new Date()): string {
-  return `${date.getFullYear()}-${date.getMonth().toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+  return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
 }
 
 /** Returns the time in hh:mm:ss format. */


### PR DESCRIPTION
Turns out Date.prototype.getMonth() is zero-based.